### PR TITLE
fix(nearby): use GeoFireX for radius queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8962,6 +8962,11 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
     },
+    "geofirex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/geofirex/-/geofirex-0.1.0.tgz",
+      "integrity": "sha512-3I1HJuWYUI4Re85meprZZapcwq4Zc47ZaL8Z16dRT3Z3OT1yRl6l9Zcepz86mEqk2VmejtwBfERXfl0YcbAWJQ=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cheerio": "1.0.0-rc.3",
     "csv-writer": "1.6.0",
     "firebase": "7.14.2",
+    "geofirex": "^0.1.0",
     "jimp": "0.10.3",
     "react": "16.13.1",
     "react-bootstrap": "1.0.1",
@@ -27,6 +28,7 @@
     "react-window": "1.8.5",
     "reactjs-popup": "1.5.0",
     "reactstrap": "8.4.1",
+    "rxjs": "^6.5.5",
     "ua-parser-js": "0.7.21"
   },
   "scripts": {

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -9,6 +9,8 @@ require('firebase/analytics');
 require('firebase/auth');
 require('firebase/storage');
 
+const geofirex = require("geofirex");
+
 firebase.initializeApp({
     apiKey: `${process.env.FIRESTORE_KEY}`,
     authDomain: "hawkercentral.firebaseapp.com",
@@ -19,11 +21,15 @@ firebase.initializeApp({
     appId: "1:596185831538:web:9cbfb234d1fff146cf8aeb",
     measurementId: "G-Z220VNJFT9"
   });
-firebase.analytics()
+firebase.analytics();
 
 const db = firebase.firestore();
-const storage = firebase.storage()
+const storage = firebase.storage();
+
+const geo = geofirex.init(firebase);
+const geoToPromise = geofirex.get;
 
 export  {
+    geo, geoToPromise,
     db, storage, firebase as default
 }

--- a/src/Components/Nearby.js
+++ b/src/Components/Nearby.js
@@ -9,9 +9,8 @@ import Item from "./Item";
 import "react-multi-carousel/lib/styles.css";
 import queryString from "query-string";
 import { Spinner } from "react-bootstrap";
-import { db } from "./Firestore";
 import Select from "react-select";
-import firebase from "./Firestore";
+import firebase, { db, geo, geoToPromise } from "./Firestore";
 import Helpers from "../Helpers/helpers";
 
 const analytics = firebase.analytics();
@@ -129,27 +128,53 @@ export class Nearby extends React.Component {
     this.setState({ data: val });
   }
 
+  mapSnapshotToDocs = (snapshot) => {
+    const data = [];
+    snapshot.forEach((doc) => {
+      if (doc.exists) {
+        const temp = doc.data();
+        temp.id = doc.id;
+        data.push(temp);
+      }
+    });
+    return data;
+  }
+
   retrieveData = async () => {
-    let data = [];
-    let temp;
-    await db
-      .collection("hawkers")
-      // .limit(100)
-      .get()
-      .then((snapshot) => {
-        snapshot.forEach((doc) => {
-          if (doc.exists) {
-            temp = doc.data();
-            temp.id = doc.id;
-            data.push(temp);
-          }
-        });
-        return true;
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-    this.setState({ data: data, retrieved: true });
+    const centre = geo.point(Number(this.state.latitude), Number(this.state.longitude));
+
+    let data;
+    if (this.state.pickup) {
+      data = await geoToPromise(
+        geo.query("hawkers")
+          .within(centre, Number(this.state.distance), "location")
+      );
+    } else if (this.state.delivery) {
+      // Find both places within a radius and places that
+      // do islandwide delivery, populate an Object keying 
+      // by doc id to avoid duplicates, then set data to 
+      // Object's valuess
+      const placesById = {}
+
+      const placesWithinReach = await geoToPromise(
+        geo.query("hawkers")
+          .within(centre, 10, "location")
+      );
+      placesWithinReach.forEach(d => placesById[d.id] = d);
+
+      const islandwide = await db.collection("hawkers")
+        .where("regions", "array-contains", "Islandwide")
+        .get()
+        .then(this.mapSnapshotToDocs);
+      islandwide.forEach(d => placesById[d.id] = d);
+
+      data = Object.values(placesById);
+    } else {
+      data = await db.collection("hawkers").get()
+        .then(this.mapSnapshotToDocs)
+    }
+
+    this.setState({ data, retrieved: true });
   };
 
   handleCuisineChange(option) {
@@ -262,17 +287,9 @@ export class Nearby extends React.Component {
       );
 
       if (this.state.pickup) {
-        filtered = this.state.data.filter(
-          (d) =>
-            (distance_calc(parseFloat(d["latitude"]), parseFloat(d["longitude"]), parseFloat(latitude), parseFloat(longitude)) <
-            this.state.distance) && d.pickup_option
-        );
+        filtered = this.state.data.filter((d) => d.pickup_option);
       } else if (this.state.delivery) {
-        filtered = this.state.data.filter(
-          (d) =>
-            (distance_calc(d["latitude"], d["longitude"], parseFloat(latitude), parseFloat(longitude)) <=
-              10 || (d.region? d.region.filter((f) => f.value === "islandwide").length >= 1:false)) && d.delivery_option
-        );
+        filtered = this.state.data.filter((d) => d.delivery_option);
       }
 
       if (


### PR DESCRIPTION
- Drop geofirex and dependencies into project
- Expose geo-related scaffolding via `src/Components/Firestore`
- Rework queries to `db.collection("hawkers")` so that location is
  specified as a search criterion. Further, if we are looking at
  delivery, make a second query for islandwide places
- Clean-up filtering logic, dropping client-side distance filtering,
  as it is no longer needed

Fixes #9