### PR TITLE
refactor(searchall): query Firebase for cuisines

### DIFF
--- a/src/Components/ListForm.js
+++ b/src/Components/ListForm.js
@@ -5,7 +5,7 @@
 
 import React, { Fragment } from "react";
 import "../App.css";
-import { db, storage } from "./Firestore";
+import { db, storage, geo } from "./Firestore";
 import { Button, Form } from "react-bootstrap";
 import logo from "../mrt_logo.png";
 import Select from "react-select";
@@ -318,18 +318,21 @@ export class ListForm extends React.Component {
       image6: this.state.image6,
       name: this.state.name,
       cuisine: this.state.cuisineValue,
+      categories: this.state.cuisineValue.map(v => v.label.trim()),
       postal: this.state.postal,
       street: this.state.street,
       unit: this.state.unit,
       description: this.state.description,
       description_detail: this.state.description_detail,
       region: this.state.region,
+      regions: this.state.region.map(v => v.label.trim()),
       islandwide: this.state.islandwide,
       delivery: this.state.delivery,
       price: this.state.price,
       contact: this.state.contact,
       latitude: this.state.latitude,
       longitude: this.state.longitude,
+      location: geo.point(Number(this.state.latitude), Number(this.state.longitude)),
       call: this.state.call,
       whatsapp: this.state.whatsapp,
       sms: this.state.sms,

--- a/src/Components/Nearby.js
+++ b/src/Components/Nearby.js
@@ -128,18 +128,6 @@ export class Nearby extends React.Component {
     this.setState({ data: val });
   }
 
-  mapSnapshotToDocs = (snapshot) => {
-    const data = [];
-    snapshot.forEach((doc) => {
-      if (doc.exists) {
-        const temp = doc.data();
-        temp.id = doc.id;
-        data.push(temp);
-      }
-    });
-    return data;
-  }
-
   retrieveData = async () => {
     const centre = geo.point(Number(this.state.latitude), Number(this.state.longitude));
 
@@ -165,13 +153,13 @@ export class Nearby extends React.Component {
       const islandwide = await db.collection("hawkers")
         .where("regions", "array-contains", "Islandwide")
         .get()
-        .then(this.mapSnapshotToDocs);
+        .then(Helpers.mapSnapshotToDocs);
       islandwide.forEach(d => placesById[d.id] = d);
 
       data = Object.values(placesById);
     } else {
       data = await db.collection("hawkers").get()
-        .then(this.mapSnapshotToDocs)
+        .then(Helpers.mapSnapshotToDocs)
     }
 
     this.setState({ data, retrieved: true });

--- a/src/Components/SearchAll.js
+++ b/src/Components/SearchAll.js
@@ -86,26 +86,10 @@ export class SearchAll extends React.Component {
   }
 
   retrieveData = async () => {
-    let data = [];
-    let temp;
-    await db
-      .collection("hawkers")
-      .get()
-      .then((snapshot) => {
-        snapshot.forEach((doc) => {
-          if (doc.exists) {
-            temp = doc.data();
-            temp.id = doc.id;
-            data.push(temp);
-          }
-        });
-        console.log("Fetched successfully!");
-        return true;
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-    this.setState({ data: data, retrieved: true });
+    let query = db.collection("hawkers");
+    const data = await query.get()
+      .then(Helpers.mapSnapshotToDocs);
+    this.setState({ data, retrieved: true });
   };
 
   handleCuisineChange(option) {

--- a/src/Components/SearchAll.js
+++ b/src/Components/SearchAll.js
@@ -113,6 +113,8 @@ export class SearchAll extends React.Component {
         <span>
           <Select
             isMulti
+            closeMenuOnSelect={false}
+            isDisabled={!this.state.retrieved}
             name="name"
             options={cuisine_format}
             className="basic-multi-select"
@@ -297,58 +299,54 @@ export class SearchAll extends React.Component {
     }
 
     return (
-      <div>
-        {this.state.retrieved ? (
-          <div>
-            <div
-              class="container"
-              style={{ paddingTop: "56px", width: "100%" }}
-            >
-              <div class="container" style={{ paddingTop: "27px" }}>
-                <div class="row justify-content-center">
-                  <div class="col-12 col-sm-10 col-md-6">
-                    <h3>All Listings</h3>
-                  </div>
-                </div>
-                <div class="row justify-content-center mt-4">
-                  <div class="col-12 col-sm-10 col-md-6">
-                    <input
-                      class="form-control"
-                      type="text"
-                      // value={this.state.search}
-                      name="search"
-                      placeholder="   Search by Name, Category, Food, Items e.g. Chicken Rice"
-                      style={{
-                        width: "100%",
-                        height: "38px",
-                        "border-radius": "1rem",
-                      }}
-                      onChange={this.handleChange}
-                    ></input>
-                  </div>
-                  <div class="col-12 col-sm-10 col-md-5">
-                    {this.cuisineSearch()}
-                  </div>
-                </div>
-                <div className="row justify-content-center mt-4">
-                  {result.nearby.length > 0 ? (
-                    result.nearby
-                  ) : (
-                    <span class="mt-5">No Results Found</span>
-                  )}
+      <div
+        class="container"
+        style={{ paddingTop: "56px", width: "100%" }}
+      >
+        <div class="container" style={{ paddingTop: "27px" }}>
+          <div class="row justify-content-center">
+            <div class="col-12 col-sm-10 col-md-6">
+              <h3>All Listings</h3>
+            </div>
+          </div>
+          <div class="row justify-content-center mt-4">
+            <div class="col-12 col-sm-10 col-md-6">
+              <input
+                disabled={!this.state.retrieved}
+                class="form-control"
+                type="text"
+                // value={this.state.search}
+                name="search"
+                placeholder="   Search by Name, Category, Food, Items e.g. Chicken Rice"
+                style={{
+                  width: "100%",
+                  height: "38px",
+                  "border-radius": "1rem",
+                }}
+                onChange={this.handleChange}
+              ></input>
+            </div>
+            <div class="col-12 col-sm-10 col-md-5">
+              {this.cuisineSearch()}
+            </div>
+          </div>
+          <div className="row justify-content-center mt-4">
+            {this.state.retrieved ? (
+              result.nearby.length > 0 ? (
+                result.nearby
+              ) : (
+                <span class="mt-5">No Results Found</span>
+              )
+            ) : (
+              <div class="row h-100 page-container">
+                <div class="col-sm-12 my-auto">
+                  <h3>Loading</h3>
+                  <Spinner class="" animation="grow" />
                 </div>
               </div>
-              <div></div>
-            </div>
+            )}
           </div>
-        ) : (
-          <div class="row h-100 page-container">
-            <div class="col-sm-12 my-auto">
-              <h3>Loading</h3>
-              <Spinner class="" animation="grow" />
-            </div>
-          </div>
-        )}
+        </div>
       </div>
     );
   }

--- a/src/Helpers/helpers.js
+++ b/src/Helpers/helpers.js
@@ -26,8 +26,26 @@ function capitalizeFirstLetter (sentence) {
 	return words.join(" ");
 }
 
+/**
+ * Unpack a Firebase QuerySnapshot and extract its documents
+ * @param {firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>} snapshot - the query result
+ * @returns {firebase.firestore.DocumentData[]} an array of Firestore documents, 
+ * each injected with the field `id`, equivalent to `docid`
+ */
+function mapSnapshotToDocs (snapshot) {
+	const data = [];
+	snapshot.forEach((doc) => {
+		if (doc.exists) {
+			const temp = doc.data();
+			temp.id = doc.id;
+			data.push(temp);
+		}
+	});
+	return data;
+}
 
 export default {
 	compareString,
-	capitalizeFirstLetter
+	capitalizeFirstLetter,
+	mapSnapshotToDocs
 }


### PR DESCRIPTION
SearchAll currently retrieves all known listings before performing
client-side filtering. This will not work as well with more entries,
so move as much of the search/filtering to Firestore as practically
possible

- move `mapSnapshotToDocuments()` to Helpers

- make adjustments to the UI so that the user can continue to see 
  his/her input even when a query is fired off with the specified cuisine options
  - Show but disable the search controls while `retrieved` is false
  - Allow the menu to remain open so that user doesn't have to reopen
  the menu with each selected option

- state: declare a new boolean flag to track when the cuisine
  dropdown menu is open/closed
- Cuisine menu: add handlers to update `state.isCuisineMenuOpen`
  - trigger data retrieval on menu close

- handleCuisineChange():
  - convert to arrow function so that `this`
    scope is automatically bound to the SearchAll instance
  - if this function is triggered when the menu is closed, trigger
    data retrieval

- retrieveData():
  - always reset `state.retrieved` to `false` on entering
  - if `state.cuisineValue` is empty, add it to the Firestore query

- Remove client-side cuisine filtering
- Ensure categories, regions, geopoint location populated for new entries