### PR TITLE
Add original store name as part of edit email

### DIFF
--- a/src/Components/ListForm.js
+++ b/src/Components/ListForm.js
@@ -104,6 +104,7 @@ const handleData = async ({
   menu_combined,
   tagsValue,
   editedFields,
+  originalName
 }) => {
   let now = new Date();
   var field = {
@@ -167,7 +168,7 @@ const handleData = async ({
   } else if (toggle === "edit") {
     if (editedFields.length > 0) {
       let editedFieldsAndValues = _.pick(field, editedFields);
-      await Helpers.sendEmailToUpdateListing(docid, editedFieldsAndValues)
+      await Helpers.sendEmailToUpdateListing(docid, originalName, editedFieldsAndValues)
         .then((result) => {
           console.log(result);
         })
@@ -439,6 +440,7 @@ export class ListForm extends React.Component {
       wechatid: this.state.wechatid,
       tagsValue: this.state.tagsValue,
       editedFields: edited_fields,
+      originalName: this.initialState.name,
     }).then((id) => {
       if (this.props.toggle === "create") {
         this.props.history.push({

--- a/src/Helpers/helpers.js
+++ b/src/Helpers/helpers.js
@@ -51,10 +51,11 @@ function mapSnapshotToDocs (snapshot) {
  * @param doc_id - document id as assigned in Firebase
  * @param listform_fields - listform fields with proposed updates
  */
-async function sendEmailToUpdateListing(doc_id, listform_fields) {
+async function sendEmailToUpdateListing(doc_id, originalName, listform_fields) {
 	const EMAIL_API_KEY = 'user_VLX3sOLJCtcJAQ7SKiVLe'//`${process.env.REACT_APP_EMAIL_API_KEY}`;
 	const email_params = {
 		listing_id: doc_id,
+		listing_name: originalName,
 		message: JSON.stringify(listform_fields, null, 2),
 	}
 


### PR DESCRIPTION
Related to #8 

The original store name has been added to the email sent whenever a listing is edited so that it is easier to identify the listing in question.