### PR TITLE
feat(item): use images.weserv.nl for thumbnails

### DIFF
--- a/src/Components/Item.js
+++ b/src/Components/Item.js
@@ -22,6 +22,10 @@ export class Item extends React.Component {
     }
   };
 
+  thumbnail = () => {
+    return `https://images.weserv.nl/?w=178&url=${encodeURIComponent(this.props.pic)}`
+  }
+
   render() {
     return (
       <div>
@@ -52,7 +56,7 @@ export class Item extends React.Component {
                     </div>
                   ) : null}
                   <div style={{ height: "120px" }}>
-                    <img src={this.props.pic} class="card-img-top" alt="" />
+                    <img src={this.thumbnail()} class="card-img-top" alt="" />
                   </div>
                 </div>
               ) : (


### PR DESCRIPTION
Item cards currently use full-size images of an outlet as-is, despite
the image section of the card being only 178x120px. This hurts users
with limited battery and bandwidth, especially given that at 200ish kb
per image, fetching all the card images for SearchAll would be
more than 100MB to download.

Use [images.weserv.nl](https://images.weserv.nl) to make thumbnails on the fly for free, to reduce
image download sizes by about 90%. weserv uses CloudFlare as a CDN,
so generated thumbnails would be cached and quickly served on demand.

Further addresses #23