### PR TITLE
Fix size of Whatsapp icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5242,6 +5242,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bitly": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bitly/-/bitly-7.1.0.tgz",
+      "integrity": "sha512-wUvd7XN/hXAtiw0/zKinPBf+71kbj5gSn+JWYkcaHKyAIah4ic98HTDPszKNa3+3Qf6cLFTRySQzN/drZK7OpA==",
+      "requires": {
+        "axios": "^0.19.2",
+        "valid-url": "^1.0.9"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -20473,6 +20482,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -1542,7 +1542,7 @@ export class Info extends React.Component {
                       <img
                         alt=""
                         src={whatsapp_icon}
-                        style={{ width: "6.5%", cursor: "pointer" }}
+                        style={{ width: "32px", cursor: "pointer" }}
                       />
                     </a>
                   </span>


### PR DESCRIPTION
Fix the size of the Whatsapp icon by setting it to the same width as the other icons. This allows all the icons to be consistently sized even when viewed on mobile.

