### PR TITLE
 feat(item): lazy-load images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10781,8 +10781,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -11152,8 +11151,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11171,13 +11169,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11190,18 +11186,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11304,8 +11297,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11315,7 +11307,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11328,20 +11319,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11358,7 +11346,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -11414,8 +11401,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -11440,8 +11426,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11451,7 +11436,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11520,8 +11504,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11551,7 +11534,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11569,7 +11551,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11608,13 +11589,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -13363,8 +13342,7 @@
       "version": "2.25.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
       "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -13804,8 +13782,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "shallow-clone": {
           "version": "3.0.1",
@@ -16922,6 +16899,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-lazy-load-image-component": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.3.tgz",
+      "integrity": "sha512-F7SuCjqJkfRUXAcVxx3mms92mbO6W20v+utPRAQHHncT6KJF61XPo1TLL2e+9LhuA/KZkIsSr7xo7srItbVefg==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -20742,8 +20728,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -20761,13 +20746,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -20780,18 +20763,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -20894,8 +20874,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -20905,7 +20884,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -20918,20 +20896,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -20948,7 +20923,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -21004,8 +20978,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -21030,8 +21003,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -21041,7 +21013,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -21110,8 +21081,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -21141,7 +21111,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -21159,7 +21128,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -21198,13 +21166,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -21526,8 +21492,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -21545,13 +21510,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -21564,18 +21527,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -21678,8 +21638,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -21689,7 +21648,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -21702,20 +21660,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -21732,7 +21687,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -21788,8 +21742,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -21814,8 +21767,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -21825,7 +21777,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -21894,8 +21845,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -21925,7 +21875,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -21943,7 +21892,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -21982,13 +21930,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -23031,8 +22977,7 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-helmet": "6.0.0",
     "react-i18next": "11.4.0",
     "react-image-gallery": "1.0.7",
+    "react-lazy-load-image-component": "^1.4.3",
     "react-linkify": "1.0.0-alpha",
     "react-multi-carousel": "2.5.5",
     "react-router-dom": "5.2.0",

--- a/src/Components/Item.js
+++ b/src/Components/Item.js
@@ -4,10 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import React from "react";
+import { withRouter } from "react-router-dom";
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+
+import { LanguageContext } from "./themeContext";
+
 import "../App.css";
 import placeholder from "../placeholder.png";
-import { withRouter } from "react-router-dom";
-import { LanguageContext } from "./themeContext";
 
 export class Item extends React.Component {
   handleClick = async (event) => {
@@ -53,13 +56,14 @@ export class Item extends React.Component {
                   </span>
                 </div>
               ) : null}
-              <div style={{ height: "120px" }}>
-                {this.props.pic ? (
-                  <img src={this.thumbnail()} class="card-img-top" alt="" />
-                ) : (
-                  <img src={placeholder} class="card-img-top" alt="" />
-                )}
-              </div>
+              <LazyLoadImage
+                src={this.props.pic ? this.thumbnail() : placeholder} 
+                placeholderSrc={placeholder}
+                style={{ height: "120px" }}
+                class="card-img-top" 
+                height="120"
+                alt="" 
+              />
               {this.props.promo ? (
                 <div
                   style={{

--- a/src/Components/Item.js
+++ b/src/Components/Item.js
@@ -36,34 +36,30 @@ export class Item extends React.Component {
               style={{ margin: "5px" }}
               onClick={this.handleClick}
             >
-              {this.props.pic ? (
-                <div>
-                  {this.props.distance ? (
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: "105px",
-                        right: "5px",
-                        zIndex: "1",
-                      }}
-                    >
-                      <span
-                        class="badge badge-info"
-                        style={{ backgroundColor: "#b48300" }}
-                      >
-                        {this.props.distance.slice(0, 4) + " km away"}
-                      </span>
-                    </div>
-                  ) : null}
-                  <div style={{ height: "120px" }}>
-                    <img src={this.thumbnail()} class="card-img-top" alt="" />
-                  </div>
+              {this.props.distance ? (
+                <div
+                  style={{
+                    position: "absolute",
+                    top: "105px",
+                    right: "5px",
+                    zIndex: "1",
+                  }}
+                >
+                  <span
+                    class="badge badge-info"
+                    style={{ backgroundColor: "#b48300" }}
+                  >
+                    {this.props.distance.slice(0, 4) + " km away"}
+                  </span>
                 </div>
-              ) : (
-                <div style={{ height: "120px" }}>
+              ) : null}
+              <div style={{ height: "120px" }}>
+                {this.props.pic ? (
+                  <img src={this.thumbnail()} class="card-img-top" alt="" />
+                ) : (
                   <img src={placeholder} class="card-img-top" alt="" />
-                </div>
-              )}
+                )}
+              </div>
               {this.props.promo ? (
                 <div
                   style={{


### PR DESCRIPTION
Searching still consumes a lot of data, due to eager loading of images
for all entries. Use lazy loading to only get the images we need to
display.
- clean up nesting of pic, distance divs
- `npm install react-lazy-load-image-component`
- Use LazyLoadImage to load thumbnail or placeholder, depending on
  presence of `this.props.pic`
- Rely on LazyLoadImage to load image when needed