### PR TITLE
Add option to save user details for delivery form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -138,7 +138,11 @@ class App extends React.Component {
               <Route exact path="/driver" component={Components.Driver} />
               <Route exact path="/delivery" component={Components.Delivery} />
               <Route exact path="/orders" component={Components.Orders} />
-              <Route exact path="/deliveries" component={Components.Deliveries} />
+              <Route
+                exact
+                path="/deliveries"
+                component={Components.Deliveries}
+              />
               <script src="/__/firebase/7.14.1/firebase-app.js"></script>
               <script src="/__/firebase/7.14.1/firebase-analytics.js"></script>
               <script src="/__/firebase/init.js"></script>

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -7,7 +7,7 @@ import React from "react";
 import "../App.css";
 import "react-multi-carousel/lib/styles.css";
 import queryString from "query-string";
-import { Button, Spinner, Form } from "react-bootstrap";
+import { Button, Spinner, Form, Popover, OverlayTrigger } from "react-bootstrap";
 import { db } from "./Firestore";
 import ImageGallery from "react-image-gallery";
 import Component from "./index";
@@ -87,6 +87,14 @@ function ScrollTop(props) {
   );
 }
 
+const popover = (
+  <Popover>
+    <Popover.Content>
+      Your details will only be stored in your browser!
+    </Popover.Content>
+  </Popover>
+);
+
 export class Info extends React.Component {
   constructor(props) {
     super(props);
@@ -109,11 +117,13 @@ export class Info extends React.Component {
       activePhoto: 1,
       hasReviewEditMessage: false,
       hasReviewDeleteMessage: false,
+      shouldRememberDetails: false,
     };
     this.enterDetails = this.enterDetails.bind(this);
     this.handleCustomerDetails = this.handleCustomerDetails.bind(this);
     this.setOrderText = this.setOrderText.bind(this);
     this.formatSummary = this.formatSummary.bind(this);
+    this.toggleShouldRememberDetails = this.toggleShouldRememberDetails.bind(this);
   }
 
   componentWillMount() {
@@ -144,6 +154,11 @@ export class Info extends React.Component {
         console.log(error);
       });
   };
+
+  toggleShouldRememberDetails(event) {
+    const isChecked = event.target.checked;
+    this.setState({ shouldRememberDetails: isChecked });
+  }
 
   handleCustomerDetails = async (event) => {
     const inputValue = event.target.value;
@@ -1468,7 +1483,6 @@ export class Info extends React.Component {
                                     placeholder=""
                                   ></input>
                                 </div> */}
-
                                 <div class="form-group create-title">
                                   <label for="address">Comments</label>
                                   <input
@@ -1482,6 +1496,20 @@ export class Info extends React.Component {
                                     }}
                                     placeholder="No chilli etc, leave blank if nil"
                                   ></input>
+                                </div>
+                                <div class="form-group create-title">
+                                  <OverlayTrigger trigger={["hover", "focus"]} placement="top" overlay={popover}>
+                                    <label for="remember">Remember me?</label>
+                                  </OverlayTrigger>
+                                    <input
+                                      name="shouldRememberDetails"
+                                      type="checkbox"
+                                      checked={this.state.shouldRememberDetails}
+                                      onChange={this.toggleShouldRememberDetails}
+                                      style={{
+                                        marginLeft: "10px",
+                                      }}
+                                    ></input>
                                 </div>
                                 <Button
                                   class="shadow-sm"

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -121,6 +121,7 @@ export class Info extends React.Component {
     };
     this.enterDetails = this.enterDetails.bind(this);
     this.handleCustomerDetails = this.handleCustomerDetails.bind(this);
+    this.updateCustomerDetails = this.updateCustomerDetails.bind(this);
     this.setOrderText = this.setOrderText.bind(this);
     this.formatSummary = this.formatSummary.bind(this);
     this.toggleShouldRememberDetails = this.toggleShouldRememberDetails.bind(this);
@@ -129,6 +130,12 @@ export class Info extends React.Component {
   componentWillMount() {
     this.getDoc();
     console.log("run");
+
+    if (localStorage.getItem("userDetails")) {
+      const userDetails = JSON.parse(localStorage.getItem("userDetails"));
+      this.setState(userDetails);
+      this.setState({ shouldRememberDetails: true });
+    }
   }
 
   getDoc = async () => {
@@ -155,12 +162,28 @@ export class Info extends React.Component {
       });
   };
 
+  updateSavedData(isChecked) {
+    if (!isChecked) {
+      localStorage.clear();
+    } else {
+      const userDetails = {
+        name: this.state.name,
+        customerNumber: this.state.customerNumber,
+        postal: this.state.postal,
+        unit: this.state.unit,
+        street: this.state.street
+      };
+      localStorage.setItem("userDetails", JSON.stringify(userDetails));
+    }
+  }
+
   toggleShouldRememberDetails(event) {
     const isChecked = event.target.checked;
     this.setState({ shouldRememberDetails: isChecked });
+    this.updateSavedData(isChecked);
   }
 
-  handleCustomerDetails = async (event) => {
+  updateCustomerDetails = async(event) => {
     const inputValue = event.target.value;
     const inputField = event.target.name;
     if (inputField === "name") {
@@ -199,6 +222,13 @@ export class Info extends React.Component {
         await this.getPostal(inputValue);
       }
     }
+  }
+
+  handleCustomerDetails = async (event) => {
+    await this.updateCustomerDetails(event)
+      .then(() => {
+        this.updateSavedData(this.state.shouldRememberDetails);
+      });
   };
 
   async getPostal(postal) {


### PR DESCRIPTION
This adds a "Remember me?" checkbox to the delivery order form, and stores the user's name, mobile number, postal code, unit number and street name when the checkbox is checked. Fields such as the comment field and delivery time field are not stored since storing these fields are unlikely to be useful for the user.

Note that the `handleCustomerDetails` function has been refactored into a separate function so that it can allow for chaining (i.e. `then`). This is because the customer details stored in local storage depends on `this.state`, so we have to ensure that `this.state` is fully updated first whenever there is a change to any customer details before we store this into local storage. Otherwise, the data stored in local storage may be incomplete (e.g. "Joh" instead of "John").

Lastly, I refactored the code in `App.js` slightly because it is failing Prettier. It seems to be related to the length of the tag having exceeded 80 characters on a single line.