### PR TITLE
Rework Info layout 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -790,6 +790,11 @@ figure.effect-bubba:hover p {
   top: 0px;
   color: rgba(189, 195, 199, 1);
 }
+
+.badge {
+  margin: 0 0.1rem;
+}
+
 /*==================== Message ======================*/
 #message {
   position: absolute;

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -1085,97 +1085,103 @@ export class Info extends React.Component {
                   </span>
                 ) : null }
               </div>
-              Share this with friends!
-              <br />
-              <FacebookShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                quote={"Hungry? Try out " + this.state.data.name + " now!"}
-                hashtag={"#saveourFnB"}
-              >
-                <FacebookIcon size={32} round={true} />
-              </FacebookShareButton>{" "}
-              <span className="" style={{ marginRight: "5px" }}>
-                <a
-                  href={
-                    "whatsapp://send?text=" +
-                    encodeURIComponent(
-                      "Hungry? Try out " +
-                        this.state.data.name +
-                        " now! Order form / more information at www.foodleh.app/info?id=" +
-                        this.state.id
-                    )
-                  }
-                >
-                  <img
-                    alt=""
-                    src={whatsapp_icon}
-                    style={{ width: "32px", cursor: "pointer" }}
-                  />
-                </a>
-              </span>
-              {/* <WhatsappShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <WhatsappIcon size={32} round={true} />
-              </WhatsappShareButton>{" "} */}
-              <TelegramShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <TelegramIcon size={32} round={true} />
-              </TelegramShareButton>{" "}
-              <TwitterShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <TwitterIcon size={32} round={true} />
-              </TwitterShareButton>{" "}
-              <Clap
-                collection={"hawkers"}
-                id={this.state.id}
-                claps={this.state.data.claps}
-              />
               <Component.Popup
                 data={this.state.data}
                 id={this.state.id}
                 onSubmitEdit={this.showReviewEditMessage}
                 onSubmitDelete={this.showReviewDeleteMessage}
               />
-              <br />
-              {this.state.data.promo ? (
-                <div
-                  className="card shadow"
-                  style={{
-                    color: "black",
-                    backgroundColor: "white",
-                    height: "35px",
-                  }}
-                >
-                  <span className="card-body">
-                    <div
-                      className="card-title"
-                      style={{
-                        position: "absolute",
-                        top: "6px",
-                        fontSize: "13px",
-                      }}
-                    >
-                      <b>{this.state.data.promo}</b>:{" "}
-                      {this.state.data.condition &&
-                      this.state.data.condition.length > 40
-                        ? this.state.data.condition.slice(0, 40) + "..."
-                        : this.state.data.condition}
-                    </div>
-                  </span>
+              <div className="row" style={{ margin: "1rem 0"}}>
+                <div className="col-xs-6 col-sm-6 col-md-6 col-lg-6" style={{ padding: "0"  }}>
+                  <Clap
+                    collection={"hawkers"}
+                    id={this.state.id}
+                    claps={this.state.data.claps}
+                  />
                 </div>
-              ) : null}
+                <div className="col-xs-6 col-sm-6 col-md-6 col-lg-6" style={{ padding: "0"  }}>
+                  Share this with friends!
+                  <br />
+                  <FacebookShareButton
+                    url={"www.foodleh.app/info?id=" + this.state.id}
+                    quote={"Hungry? Try out " + this.state.data.name + " now!"}
+                    hashtag={"#saveourFnB"}
+                  >
+                    <FacebookIcon size={32} round={true} />
+                  </FacebookShareButton>{" "}
+                  <span className="" style={{ marginRight: "5px" }}>
+                    <a
+                      href={
+                        "whatsapp://send?text=" +
+                        encodeURIComponent(
+                          "Hungry? Try out " +
+                            this.state.data.name +
+                            " now! Order form / more information at www.foodleh.app/info?id=" +
+                            this.state.id
+                        )
+                      }
+                    >
+                      <img
+                        alt=""
+                        src={whatsapp_icon}
+                        style={{ width: "32px", cursor: "pointer" }}
+                      />
+                    </a>
+                  </span>
+                  {/* <WhatsappShareButton
+                    url={"www.foodleh.app/info?id=" + this.state.id}
+                    title={"Hungry? Try out " + this.state.data.name + " now!"}
+                  >
+                    <WhatsappIcon size={32} round={true} />
+                  </WhatsappShareButton>{" "} */}
+                  <TelegramShareButton
+                    url={"www.foodleh.app/info?id=" + this.state.id}
+                    title={"Hungry? Try out " + this.state.data.name + " now!"}
+                  >
+                    <TelegramIcon size={32} round={true} />
+                  </TelegramShareButton>{" "}
+                  <TwitterShareButton
+                    url={"www.foodleh.app/info?id=" + this.state.id}
+                    title={"Hungry? Try out " + this.state.data.name + " now!"}
+                  >
+                    <TwitterIcon size={32} round={true} />
+                  </TwitterShareButton>{" "}
+                </div>
+
+              </div>
+                {this.state.data.promo ? (
+                  <div
+                    className="card shadow"
+                    style={{
+                      color: "black",
+                      backgroundColor: "white",
+                      height: "35px",
+                    }}
+                  >
+                    <span className="card-body">
+                      <div
+                        className="card-title"
+                        style={{
+                          position: "absolute",
+                          top: "6px",
+                          fontSize: "13px",
+                        }}
+                      >
+                        <b>{this.state.data.promo}</b>:{" "}
+                        {this.state.data.condition &&
+                        this.state.data.condition.length > 40
+                          ? this.state.data.condition.slice(0, 40) + "..."
+                          : this.state.data.condition}
+                      </div>
+                    </span>
+                  </div>
+                ) : null}
+              </div>
             </div>
-          </div>
 
           <div
-            className="jumbotron col-xs-6 col-sm-6 col-md-6 col-lg-6"
-            style={{ height: "320px", backgroundColor: "white" }}
+            className="col-xs-6 col-sm-6 col-md-6 col-lg-6"
+            style={{ padding: "2.5rem 1rem", height: "320px", backgroundColor: "white" }}
           >
             {/* <img src={this.state.data.url} /> */}
             <div style={{ alignItems: "center" }}>

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -238,39 +238,17 @@ export class Info extends React.Component {
   }
 
   updateCustomerDetails = async (event) => {
-    const inputValue = event.target.value;
-    const inputField = event.target.name;
-    if (inputField === "name") {
+    const { name: inputField, value: inputValue } = event.target;
+    const inputFields = [
+      "name", "address", "notes", "customerNumber", "unit", "street", "postal"
+    ];
+    if (inputFields.includes(inputField)) {
       this.setState({
-        name: inputValue,
-      });
-    } else if (inputField === "address") {
-      this.setState({
-        address: inputValue,
-      });
-    } else if (inputField === "notes") {
-      this.setState({
-        notes: inputValue,
-      });
-    } else if (inputField === "customerNumber") {
-      this.setState({
-        customerNumber: inputValue,
-      });
-    } else if (inputField === "unit") {
-      this.setState({
-        unit: inputValue,
-      });
-    } else if (inputField === "street") {
-      this.setState({
-        street: inputValue, // TODO: autofill
-      });
-    } else if (inputField === "postal") {
-      this.setState({
-        postal: inputValue,
-      });
-      if (inputValue.length === 6) {
-        await this.getPostal(inputValue);
-      }
+        [inputField]: inputValue,
+      })
+    }
+    if (inputField === "postal" && inputValue.length === 6) {
+      await this.getPostal(inputValue);
     }
   };
 

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -905,29 +905,6 @@ export class Info extends React.Component {
           </div>
         ) : null}
         <div className="row">
-          <div
-            className="jumbotron col-xs-6 col-sm-6 col-md-6 col-lg-6"
-            style={{ height: "320px", backgroundColor: "white" }}
-          >
-            {/* <img src={this.state.data.url} /> */}
-            <div style={{ alignItems: "center" }}>
-              {photos.length !== 0 ? (
-                <ImageGallery
-                  items={photos}
-                  renderFullscreenButton={this.renderFullscreenButton}
-                  // lazyLoad={false}
-                  useBrowserFullscreen={false}
-                  showPlayButton={false}
-                  useTranslate3D={false}
-                  slideDuration={100}
-                  // isRTL={false}
-                  slideInterval={2000}
-                  slideOnThumbnailOver={false}
-                  thumbnailPosition={"bottom"}
-                />
-              ) : null}
-            </div>
-          </div>
           <div className="col-xs-6 col-sm-6 col-md-6 col-lg-6">
             <div
               className="container"
@@ -1215,6 +1192,39 @@ export class Info extends React.Component {
                   </span>
                 </div>
               ) : null}
+            </div>
+          </div>
+
+          <div
+            className="jumbotron col-xs-6 col-sm-6 col-md-6 col-lg-6"
+            style={{ height: "320px", backgroundColor: "white" }}
+          >
+            {/* <img src={this.state.data.url} /> */}
+            <div style={{ alignItems: "center" }}>
+              {photos.length !== 0 ? (
+                <ImageGallery
+                  items={photos}
+                  renderFullscreenButton={this.renderFullscreenButton}
+                  // lazyLoad={false}
+                  useBrowserFullscreen={false}
+                  showPlayButton={false}
+                  useTranslate3D={false}
+                  slideDuration={100}
+                  // isRTL={false}
+                  slideInterval={2000}
+                  slideOnThumbnailOver={false}
+                  thumbnailPosition={"bottom"}
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="row">
+            <div
+              className="container"
+              style={{ textAlign: "left", paddingTop: "10px" }}
+            >
               <div>
                     {/* Display appropriate header - menu / menu with Whatsapp ordering */}
                     {this.state.data.menu &&
@@ -1987,7 +1997,6 @@ export class Info extends React.Component {
               </ScrollTop>
             </div>
           </div>
-        </div>
       </div>
     ) : (
       <div className="row h-100 page-container">

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -1073,7 +1073,7 @@ export class Info extends React.Component {
                   </span>
                 </div>
               ) : null}
-              <br />
+
               {/* Custom button display: menu, website, message */}
               <div>
                 {this.state.data.menu &&
@@ -1111,23 +1111,111 @@ export class Info extends React.Component {
                   </a>
                 ) : null}
                 {this.state.data.whatsapp ? (
-                  <span>
-                    <span className="">
-                      <a
-                        href={link}
-                        target="blank"
-                        onClick={() => onLoad("message", this.state.data.name)}
-                      >
-                        <img
-                          alt=""
-                          src={whatsapp_button}
-                          style={{
-                            width: "25%",
-                          }}
-                        />
-                      </a>
-                    </span>
-
+                  <span className="">
+                    <a
+                      href={link}
+                      target="blank"
+                      onClick={() =>
+                        onLoad("message", this.state.data.name)
+                      }
+                    >
+                      <img
+                        alt=""
+                        src={whatsapp_button}
+                        style={{
+                          width: "25%",
+                        }}
+                      />
+                    </a>
+                  </span>
+                ) : null }
+              </div>
+              Share this with friends!
+              <br />
+              <FacebookShareButton
+                url={"www.foodleh.app/info?id=" + this.state.id}
+                quote={"Hungry? Try out " + this.state.data.name + " now!"}
+                hashtag={"#saveourFnB"}
+              >
+                <FacebookIcon size={32} round={true} />
+              </FacebookShareButton>{" "}
+              <span className="" style={{ marginRight: "5px" }}>
+                <a
+                  href={
+                    "whatsapp://send?text=" +
+                    encodeURIComponent(
+                      "Hungry? Try out " +
+                        this.state.data.name +
+                        " now! Order form / more information at www.foodleh.app/info?id=" +
+                        this.state.id
+                    )
+                  }
+                >
+                  <img
+                    alt=""
+                    src={whatsapp_icon}
+                    style={{ width: "32px", cursor: "pointer" }}
+                  />
+                </a>
+              </span>
+              {/* <WhatsappShareButton
+                url={"www.foodleh.app/info?id=" + this.state.id}
+                title={"Hungry? Try out " + this.state.data.name + " now!"}
+              >
+                <WhatsappIcon size={32} round={true} />
+              </WhatsappShareButton>{" "} */}
+              <TelegramShareButton
+                url={"www.foodleh.app/info?id=" + this.state.id}
+                title={"Hungry? Try out " + this.state.data.name + " now!"}
+              >
+                <TelegramIcon size={32} round={true} />
+              </TelegramShareButton>{" "}
+              <TwitterShareButton
+                url={"www.foodleh.app/info?id=" + this.state.id}
+                title={"Hungry? Try out " + this.state.data.name + " now!"}
+              >
+                <TwitterIcon size={32} round={true} />
+              </TwitterShareButton>{" "}
+              <Clap
+                collection={"hawkers"}
+                id={this.state.id}
+                claps={this.state.data.claps}
+              />
+              <Component.Popup
+                data={this.state.data}
+                id={this.state.id}
+                onSubmitEdit={this.showReviewEditMessage}
+                onSubmitDelete={this.showReviewDeleteMessage}
+              />
+              <br />
+              {this.state.data.promo ? (
+                <div
+                  className="card shadow"
+                  style={{
+                    color: "black",
+                    backgroundColor: "white",
+                    height: "35px",
+                  }}
+                >
+                  <span className="card-body">
+                    <div
+                      className="card-title"
+                      style={{
+                        position: "absolute",
+                        top: "6px",
+                        fontSize: "13px",
+                      }}
+                    >
+                      <b>{this.state.data.promo}</b>:{" "}
+                      {this.state.data.condition &&
+                      this.state.data.condition.length > 40
+                        ? this.state.data.condition.slice(0, 40) + "..."
+                        : this.state.data.condition}
+                    </div>
+                  </span>
+                </div>
+              ) : null}
+              <div>
                     {/* Display appropriate header - menu / menu with Whatsapp ordering */}
                     {this.state.data.menu &&
                     this.state.data.whatsapp &&
@@ -1772,97 +1860,7 @@ export class Info extends React.Component {
                         </Form>
                       </div>
                     ) : null}
-                  </span>
-                ) : null}
               </div>
-              <br />
-              Share this with friends!
-              <br />
-              <FacebookShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                quote={"Hungry? Try out " + this.state.data.name + " now!"}
-                hashtag={"#saveourFnB"}
-              >
-                <FacebookIcon size={32} round={true} />
-              </FacebookShareButton>{" "}
-              <span className="" style={{ marginRight: "5px" }}>
-                <a
-                  href={
-                    "whatsapp://send?text=" +
-                    encodeURIComponent(
-                      "Hungry? Try out " +
-                        this.state.data.name +
-                        " now! Order form / more information at www.foodleh.app/info?id=" +
-                        this.state.id
-                    )
-                  }
-                >
-                  <img
-                    alt=""
-                    src={whatsapp_icon}
-                    style={{ width: "32px", cursor: "pointer" }}
-                  />
-                </a>
-              </span>
-              {/* <WhatsappShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <WhatsappIcon size={32} round={true} />
-              </WhatsappShareButton>{" "} */}
-              <TelegramShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <TelegramIcon size={32} round={true} />
-              </TelegramShareButton>{" "}
-              <TwitterShareButton
-                url={"www.foodleh.app/info?id=" + this.state.id}
-                title={"Hungry? Try out " + this.state.data.name + " now!"}
-              >
-                <TwitterIcon size={32} round={true} />
-              </TwitterShareButton>{" "}
-              <br />
-              <Component.Popup
-                data={this.state.data}
-                id={this.state.id}
-                onSubmitEdit={this.showReviewEditMessage}
-                onSubmitDelete={this.showReviewDeleteMessage}
-              />
-              <br />
-              {this.state.data.promo ? (
-                <div
-                  className="card shadow"
-                  style={{
-                    color: "black",
-                    backgroundColor: "white",
-                    height: "35px",
-                  }}
-                >
-                  <span className="card-body">
-                    <div
-                      className="card-title"
-                      style={{
-                        position: "absolute",
-                        top: "6px",
-                        fontSize: "13px",
-                      }}
-                    >
-                      <b>{this.state.data.promo}</b>:{" "}
-                      {this.state.data.condition &&
-                      this.state.data.condition.length > 40
-                        ? this.state.data.condition.slice(0, 40) + "..."
-                        : this.state.data.condition}
-                    </div>
-                  </span>
-                </div>
-              ) : null}
-              <br />
-              <Clap
-                collection={"hawkers"}
-                id={this.state.id}
-                claps={this.state.data.claps}
-              />
               {this.state.data.description ? (
                 <div>
                   <br />

--- a/src/Components/Info.js
+++ b/src/Components/Info.js
@@ -1228,35 +1228,13 @@ export class Info extends React.Component {
               <div>
                     {/* Display appropriate header - menu / menu with Whatsapp ordering */}
                     {this.state.data.menu &&
-                    this.state.data.whatsapp &&
                     this.state.data.menu_combined.length > 0 &&
                     this.state.data.menu_combined[0].name !== "" ? (
-                      <div>
-                        <br />
-                        <br />
-                        <span className="">
-                          <img
-                            alt=""
-                            src={orderleh_title}
-                            style={{ width: "60%" }}
-                          />
-                        </span>
-                      </div>
-                    ) : this.state.data.menu &&
-                      this.state.data.menu_combined.length > 0 &&
-                      this.state.data.menu_combined[0].name !== "" ? (
-                      <div>
-                        <br />
-                        <br />
-
-                        <span className="">
-                          <img
-                            alt=""
-                            src={menu_title}
-                            style={{ width: "60%" }}
-                          />
-                        </span>
-                      </div>
+                      <img
+                        alt=""
+                        src={this.state.data.whatsapp ? orderleh_title : menu_title}
+                        style={{ width: "310px" }}
+                      />
                     ) : null}
                     {/* Display the first item of the menu with a see more button - TODO: boilerplate code */}
                     {this.state.data.menu &&
@@ -1479,7 +1457,7 @@ export class Info extends React.Component {
                             <img
                               alt=""
                               src={revieworder}
-                              style={{ width: "60%" }}
+                              style={{ width: "310px" }}
                             />
                           </div>
 
@@ -1645,7 +1623,7 @@ export class Info extends React.Component {
                             <img
                               alt=""
                               src={delivery_title}
-                              style={{ width: "60%" }}
+                              style={{ width: "310px" }}
                             />
 
                             <div className="form-group create-title">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10572368/84586272-a65ac180-ae4a-11ea-93a5-878ee9b9e317.png)

A user would want to order quickly and without obstruction. The current layout places everything on the right, which is unusual given that most Foodleh users would read left-to-right. The ordering and description sections are also cramped to the right, which might make reading and interacting with the menu difficult.

This PR aims to address these concerns by rearranging the layout of the info page. 

- move social media buttons to just below the info section
  - have clap and social buttons side-by-side
- add 0.5rem space between info tags
- have order and description in its own row, after info/gallery
- place info on left, gallery on right
- rework `updateCustomerDetails()` for brevity

A future PR might shrink the image gallery to line up with the info section and move the social media section again to bring the menu and description further into focus.