### PR TITLE
Add page for customers to see their group buys

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -190,6 +190,9 @@ button:focus {
   .groupbuy-container {
     flex-direction: row;
   }
+  .groupbuy-card {
+    width: calc(50% - 10px);
+  }
   .page-card {
     width: 30% !important;
     margin: 10px 20px;
@@ -239,6 +242,9 @@ button:focus {
   }
   .groupbuy-container {
     flex-direction: row;
+  }
+  .groupbuy-card {
+    width: calc(50% - 10px);
   }
   .page-card {
     width: 30% !important;
@@ -290,6 +296,9 @@ button:focus {
   .groupbuy-container {
     flex-direction: column;
   }
+  .groupbuy-card {
+    width: 100%;
+  }
   .page-card {
     width: 70% !important;
     margin: 10px 20px;
@@ -339,6 +348,9 @@ button:focus {
   }
   .groupbuy-container {
     flex-direction: row;
+  }
+  .groupbuy-card {
+    width: calc(50% - 10px);
   }
   .page-card {
     width: 45% !important;
@@ -391,6 +403,9 @@ button:focus {
   }
   .groupbuy-container {
     flex-direction: row;
+  }
+  .groupbuy-card {
+    width: 100%;
   }
   .page-card {
     width: 100% !important;
@@ -447,6 +462,9 @@ button:focus {
   }
   .groupbuy-container {
     flex-direction: column;
+  }
+  .groupbuy-card {
+    width: 100%;
   }
   .page-card {
     width: 100% !important;
@@ -511,6 +529,9 @@ button:focus {
   }
   .groupbuy-container {
     flex-direction: column;
+  }
+  .groupbuy-card {
+    width: 100%;
   }
   .page-card {
     width: 100% !important;

--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,9 @@ button:focus {
     width: 180px !important;
     height: 250px;
   }
+  .groupbuy-container {
+    flex-direction: row;
+  }
   .page-card {
     width: 30% !important;
     margin: 10px 20px;
@@ -233,6 +236,9 @@ button:focus {
   .item-card {
     width: 180px !important;
     height: 250px;
+  }
+  .groupbuy-container {
+    flex-direction: row;
   }
   .page-card {
     width: 30% !important;
@@ -281,6 +287,9 @@ button:focus {
     width: 180px !important;
     height: 250px;
   }
+  .groupbuy-container {
+    flex-direction: column;
+  }
   .page-card {
     width: 70% !important;
     margin: 10px 20px;
@@ -327,6 +336,9 @@ button:focus {
   .item-card {
     width: 260px !important;
     height: 250px;
+  }
+  .groupbuy-container {
+    flex-direction: row;
   }
   .page-card {
     width: 45% !important;
@@ -376,6 +388,9 @@ button:focus {
   .item-card {
     width: 150px !important;
     height: 250px;
+  }
+  .groupbuy-container {
+    flex-direction: row;
   }
   .page-card {
     width: 100% !important;
@@ -429,6 +444,9 @@ button:focus {
   .item-card {
     width: 150px !important;
     height: 250px;
+  }
+  .groupbuy-container {
+    flex-direction: column;
   }
   .page-card {
     width: 100% !important;
@@ -490,6 +508,9 @@ button:focus {
   .item-card {
     width: 260px !important;
     height: 250px;
+  }
+  .groupbuy-container {
+    flex-direction: column;
   }
   .page-card {
     width: 100% !important;

--- a/src/App.js
+++ b/src/App.js
@@ -697,11 +697,20 @@ class App extends React.Component {
                   <Route exact path="/orders" component={Components.Orders} />
                   {/* Allows extra URL params for each area eg groupbuy/Tampines */}
                   <Route
-                      exact
-                      path="/groupbuy"
-                      component={Components.Groupbuy}
-                    />
-                    <Route exact path="/groupbuy/:area" component={Components.GroupbuyList} />
+                    exact
+                    path="/groupbuy"
+                    component={Components.Groupbuy}
+                  />
+                  <Route
+                    exact
+                    path="/groupbuy/:area"
+                    component={Components.GroupbuyList}
+                  />
+                  <Route
+                    exact
+                    path="/groupbuy-customer"
+                    component={Components.GroupBuyCustomer}
+                  />
                   <Route
                     exact
                     path="/deliveries"

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -1,0 +1,98 @@
+import React from "react";
+import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
+import { withRouter } from "react-router-dom";
+import Select from "react-select";
+import { db, firebase, uiConfig } from "./Firestore";
+import Cookies from "universal-cookie";
+import "../App.css";
+
+const analytics = firebase.analytics();
+const cookies = new Cookies();
+
+function onLoad(name, item) {
+  analytics.logEvent(name, { name, item });
+}
+
+export class GroupBuyCustomer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      firebaseUser: null,
+      allGroupBuys: [],
+      groupBuy: ""
+    }
+  }
+
+  componentDidMount() {
+    firebase.auth().useDeviceLanguage();
+    window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
+      "recaptcha-container",
+      {
+        size: "invisible",
+        callback: function (response) {
+          // reCAPTCHA solved
+        },
+      }
+    );
+
+    firebase.auth().onAuthStateChanged(
+      function (user) {
+        if (user) {
+          this.setState({
+            firebaseUser: user
+          });
+          onLoad("groupbuy customer", user.phoneNumber);
+        } else {
+          // no user is signed in
+        }
+      }.bind(this)
+    );
+  }
+
+  render() {
+    const verifiedUser = this.state.firebaseUser;
+    return (
+      <div
+          class="jumbotron"
+          style={{
+            "padding-top": "70px",
+            "padding-bottom": "240px",
+            height: "100%",
+            "background-color": "white",
+          }}
+        >
+        <div class="container-fluid col-md-10 content col-xs-offset-2">
+        { verifiedUser === null ? 
+          <div>
+            <div>
+              <StyledFirebaseAuth
+                uiConfig={uiConfig}
+                firebaseAuth={firebase.auth()}
+              />
+            </div>
+            <div id="recaptcha-container"></div>
+            <br />
+          </div>
+        :
+          <div>
+            <p>
+              Verified your phone number: { verifiedUser.phoneNumber }
+            </p>
+            <Select
+                isDisabled={this.state.allGroupBuys.length === 0}
+                name="groupBuy"
+                options={this.state.allGroupBuys}
+                value={this.state.groupBuy}
+                onChange={this.filterGroupBuy}
+                placeholder="Filter By Group Name"
+            />
+          </div>
+        }
+        </div>
+      </div>
+    )
+  }
+
+}
+
+export default withRouter(GroupBuyCustomer);

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -7,7 +7,10 @@ import Cookies from "universal-cookie";
 import "../App.css";
 
 const analytics = firebase.analytics();
-const cookies = new Cookies();
+const allGroupBuysOption = {
+  label: "All Group Buys",
+  value: "All Group Buys"
+};
 
 function onLoad(name, item) {
   analytics.logEvent(name, { name, item });
@@ -19,7 +22,8 @@ export class GroupBuyCustomer extends React.Component {
     this.state = {
       firebaseUser: null,
       allGroupBuys: [],
-      groupBuy: ""
+      filteredGroupBuys: [],
+      groupBuy: "",
     }
   }
 
@@ -42,6 +46,7 @@ export class GroupBuyCustomer extends React.Component {
             firebaseUser: user
           });
           onLoad("groupbuy customer", user.phoneNumber);
+          this.getGroupBuyCustomerData(user);
         } else {
           // no user is signed in
         }
@@ -49,19 +54,81 @@ export class GroupBuyCustomer extends React.Component {
     );
   }
 
+  getGroupBuyCustomerData = () => {
+    const data = [
+      {
+        active: true,
+        area: "Tampines",
+        items: [
+          {
+            name: "curry puff",
+            quantity: 2,
+            price: 3
+          },
+          {
+            name: "sardine puff",
+            quantity: 1,
+            price: 5
+          },
+        ]
+      },
+      {
+        active: true,
+        area: "Pasir Ris",
+        items: [
+          {
+            name: "curry chicken",
+            quantity: 1,
+            price: 10
+          },
+          {
+            name: "curry fish",
+            quantity: 2,
+            price: 8
+          },
+        ]
+      }
+    ];
+
+    const allGroupBuys = [allGroupBuysOption];
+    data.forEach(group => allGroupBuys.push({ label: group.area, value: group.area }));
+
+    this.setState({
+      allGroupBuys: allGroupBuys,
+      groupBuy: allGroupBuysOption,
+      filteredGroupBuys: allGroupBuys
+    });
+  }
+
+  filterGroupBuy = async(selectedOption) => {
+    let filteredGroupBuys = this.state.allGroupBuys;
+
+    if (selectedOption.value !== "All Group Buys") {
+      filteredGroupBuys = this.state.allGroupBuys.filter(groupBuy => {
+        return groupBuy.area === selectedOption.value;
+      });
+    }
+
+    this.setState({ 
+      groupBuy: selectedOption,
+      filteredGroupBuys: filteredGroupBuys 
+    });
+  }
+
   render() {
     const verifiedUser = this.state.firebaseUser;
+
     return (
       <div
-          class="jumbotron"
+          className="jumbotron"
           style={{
-            "padding-top": "70px",
-            "padding-bottom": "240px",
+            "paddingTop": "70px",
+            "paddingBottom": "240px",
             height: "100%",
-            "background-color": "white",
+            "backgroundColor": "white",
           }}
         >
-        <div class="container-fluid col-md-10 content col-xs-offset-2">
+        <div className="container-fluid col-md-10 content col-xs-offset-2">
         { verifiedUser === null ? 
           <div>
             <div>

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -37,7 +37,10 @@ export class GroupBuyCustomer extends React.Component {
       allGroupBuys: [],
       filteredGroupBuys: [],
       filterOption: allGroupBuysOption,
+      search: ""
     }
+
+    this.updateFilteredGroupBuys = this.updateFilteredGroupBuys.bind(this);
   }
 
   componentDidMount() {
@@ -70,6 +73,7 @@ export class GroupBuyCustomer extends React.Component {
   getGroupBuyCustomerData = () => {
     const data = [
       {
+        hawker: "Tiong Bahru Bakery",
         active: true,
         area: "Tampines",
         items: [
@@ -86,7 +90,8 @@ export class GroupBuyCustomer extends React.Component {
         ]
       },
       {
-        active: true,
+        hawker: "Hup Siong Chicken Rice",
+        active: false,
         area: "Pasir Ris",
         items: [
           {
@@ -103,28 +108,50 @@ export class GroupBuyCustomer extends React.Component {
       }
     ];
 
-    const allGroupBuys = [];
-    data.forEach(group => allGroupBuys.push({ label: group.area, value: group.area }));
-
     this.setState({
-      allGroupBuys: allGroupBuys,
-      filteredGroupBuys: allGroupBuys
+      allGroupBuys: data,
+      filteredGroupBuys: data
     });
   }
 
-  filterGroupBuy = async(selectedOption) => {
-    let filteredGroupBuys = this.state.allGroupBuys;
+  updateFilteredGroupBuys = async(event, meta=null) => {
+    let name = "";
+    let value = "";
+    
+    if (event.target) {
+      name = event.target.name;
+      value = event.target.value;
+    } else {
+      // this is for the react-select which does not return name directly
+      name = meta.name;
+      value = event;
+    }
 
-    if (selectedOption.value !== allGroupBuysOption.value) {
+    this.setState({ [name]: value }, () => {
+      this.filterGroupBuys();
+    });
+  }
+
+  filterGroupBuys = () => {
+    let filteredGroupBuys = this.state.allGroupBuys;
+    const status = this.state.filterOption;
+    const searchTerm = this.state.search;
+
+    const isActive = status === activeGroupBuysOption;
+    if (status.value !== allGroupBuysOption.value) {
       filteredGroupBuys = this.state.allGroupBuys.filter(groupBuy => {
-        return groupBuy.area === selectedOption.value;
+        return groupBuy.active === isActive;
       });
     }
 
-    this.setState({ 
-      filterOption: selectedOption,
-      filteredGroupBuys: filteredGroupBuys 
-    });
+    if (searchTerm) {
+      filteredGroupBuys = filteredGroupBuys.filter(groupBuy => {
+        return groupBuy.hawker.toLowerCase().includes(searchTerm.toLowerCase())
+          || groupBuy.area.toLowerCase().includes(searchTerm.toLowerCase());
+      });
+    }
+
+    this.setState({ filteredGroupBuys: filteredGroupBuys });
   }
 
   render() {
@@ -157,13 +184,33 @@ export class GroupBuyCustomer extends React.Component {
             <p>
               Verified your phone number: { verifiedUser.phoneNumber }
             </p>
-            <Select
-                isDisabled={this.state.allGroupBuys.length === 0}
-                name="groupBuy"
-                options={filterOptions}
-                value={this.state.filterOption}
-                onChange={this.filterGroupBuy}
-            />
+            <div class="row justify-content-center mt-4">
+              <div class="col-12 col-sm-6 col-md-6">
+                <input
+                  disabled={this.state.allGroupBuys.length === 0}
+                  class="form-control"
+                  type="text"
+                  name="search"
+                  value={this.state.search}
+                  placeholder="Search For Group Buy"
+                  style={{
+                    width: "100%",
+                    height: "38px",
+                    "border-radius": "1rem",
+                  }}
+                  onChange={this.updateFilteredGroupBuys}
+                ></input>
+              </div>
+              <div class="col-12 col-sm-6 col-md-6">
+                <Select
+                    isDisabled={this.state.allGroupBuys.length === 0}
+                    name="filterOption"
+                    options={filterOptions}
+                    value={this.state.filterOption}
+                    onChange={this.updateFilteredGroupBuys}
+                />
+              </div>
+            </div>
             {/* <GroupBuyList groupbuys={this.state.filteredGroupBuys}/> */}
           </div>
         }

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -2,7 +2,7 @@ import React from "react";
 import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
 import { withRouter } from "react-router-dom";
 import Select from "react-select";
-import { db, firebase, uiConfig } from "./Firestore";
+import { firebase, uiConfig } from "./Firestore";
 import { Badge, Card, CardContent, makeStyles, Table, TableBody, TableCell, 
   TableFooter, TableHead, TablePagination, TableRow } from "@material-ui/core";
   import { withStyles } from '@material-ui/core/styles';
@@ -339,15 +339,15 @@ export class GroupBuyCustomer extends React.Component {
           }}
         >
         <div className="container-fluid col-md-10 content col-xs-offset-2">
-        <div className="row justify-content-center">
-          <div className="col-12 col-sm-6 col-md-6">
-            <h3 id="back-to-top-anchor">
-              Your Group Buys
-            </h3>
+          <div className="row justify-content-center">
+            <div className="col-12 col-sm-6 col-md-6">
+              <h3 id="back-to-top-anchor">
+                Your Group Buys
+              </h3>
+            </div>
           </div>
-        </div>
         { verifiedUser === null ? 
-          <div>
+          <div className="row justify-content-center mt-4">
             <div>
               <StyledFirebaseAuth
                 uiConfig={uiConfig}
@@ -401,7 +401,6 @@ export class GroupBuyCustomer extends React.Component {
       </div>
     )
   }
-
 }
 
 export default withRouter(GroupBuyCustomer);

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -4,6 +4,7 @@ import { withRouter } from "react-router-dom";
 import Select from "react-select";
 import { db, firebase, uiConfig } from "./Firestore";
 import "../App.css";
+import { Card, CardContent, Table, TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
 
 const analytics = firebase.analytics();
 
@@ -22,12 +23,55 @@ const filterOptions = [
   inactiveGroupBuysOption
 ];
 
-// function GroupBuyList(props) {
-//   const groupBuys = props.groupBuys;
-//   const cards = groupBuys.map(groupBuy => 
-    
-//   );
-// }
+function GroupBuyList(props) {
+  const groupBuys = props.groupBuys;
+
+  const cards = groupBuys.map(groupBuy => 
+    <Card
+      key={groupBuy.hawker}
+      className="card shadow col-sm-6"
+      style={{ 
+        margin: "5px" 
+      }}
+    >
+      <CardContent>
+        <p className="card-title">{ groupBuy.hawker }</p>
+        <Table size="small" aria-label="a dense table">
+          <TableHead>
+            <TableRow>
+              <TableCell>Item Name</TableCell>
+              <TableCell align="right">Price&nbsp;(S$)</TableCell>
+              <TableCell align="right">Quantity</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groupBuy.items.map(item => (
+              <TableRow key={item.name}>
+                <TableCell component="th" scope="row">
+                  {item.name}
+                </TableCell>
+                <TableCell align="right">{item.price}</TableCell>
+                <TableCell align="right">{item.quantity}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+
+  return (
+    <div
+      className="col-sm-12 groupbuy-container mt-4"
+      style={{
+        display: "inline-flex",
+        paddingLeft: "0px"
+      }}
+    >
+      { cards }
+    </div>
+  );
+}
 
 export class GroupBuyCustomer extends React.Component {
   constructor(props) {
@@ -71,9 +115,10 @@ export class GroupBuyCustomer extends React.Component {
   }
 
   getGroupBuyCustomerData = () => {
+    // TODO: dummy data to be removed after configuring Firebase
     const data = [
       {
-        hawker: "Tiong Bahru Bakery",
+        hawker: "Tampines",
         active: true,
         area: "Tampines",
         items: [
@@ -90,7 +135,7 @@ export class GroupBuyCustomer extends React.Component {
         ]
       },
       {
-        hawker: "Hup Siong Chicken Rice",
+        hawker: "3",
         active: false,
         area: "Pasir Ris",
         items: [
@@ -168,6 +213,13 @@ export class GroupBuyCustomer extends React.Component {
           }}
         >
         <div className="container-fluid col-md-10 content col-xs-offset-2">
+        <div className="row justify-content-center">
+          <div className="col-12 col-sm-6 col-md-6">
+            <h3 id="back-to-top-anchor">
+              Your Group Buys
+            </h3>
+          </div>
+        </div>
         { verifiedUser === null ? 
           <div>
             <div>
@@ -180,15 +232,15 @@ export class GroupBuyCustomer extends React.Component {
             <br />
           </div>
         :
-          <div>
-            <p>
+          <React.Fragment>
+            <div className="row justify-content-center mt-4">
               Verified your phone number: { verifiedUser.phoneNumber }
-            </p>
-            <div class="row justify-content-center mt-4">
-              <div class="col-12 col-sm-6 col-md-6">
+            </div>
+            <div className="row justify-content-center mt-4">
+              <div className="col-12 col-sm-6 col-md-6">
                 <input
                   disabled={this.state.allGroupBuys.length === 0}
-                  class="form-control"
+                  className="form-control"
                   type="text"
                   name="search"
                   value={this.state.search}
@@ -196,12 +248,12 @@ export class GroupBuyCustomer extends React.Component {
                   style={{
                     width: "100%",
                     height: "38px",
-                    "border-radius": "1rem",
+                    "borderRadius": "1rem",
                   }}
                   onChange={this.updateFilteredGroupBuys}
                 ></input>
               </div>
-              <div class="col-12 col-sm-6 col-md-6">
+              <div className="col-12 col-sm-6 col-md-6">
                 <Select
                     isDisabled={this.state.allGroupBuys.length === 0}
                     name="filterOption"
@@ -211,8 +263,9 @@ export class GroupBuyCustomer extends React.Component {
                 />
               </div>
             </div>
-            {/* <GroupBuyList groupbuys={this.state.filteredGroupBuys}/> */}
-          </div>
+            { this.state.filteredGroupBuys &&
+              <GroupBuyList groupBuys={this.state.filteredGroupBuys}/> }
+          </React.Fragment>
         }
         </div>
       </div>

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -3,18 +3,31 @@ import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
 import { withRouter } from "react-router-dom";
 import Select from "react-select";
 import { db, firebase, uiConfig } from "./Firestore";
-import Cookies from "universal-cookie";
 import "../App.css";
 
 const analytics = firebase.analytics();
-const allGroupBuysOption = {
-  label: "All Group Buys",
-  value: "All Group Buys"
-};
 
 function onLoad(name, item) {
   analytics.logEvent(name, { name, item });
 }
+
+const allGroupBuysOption =   { label: "All", value: "All" };
+const activeGroupBuysOption = { label: "Active", value: "Active" };
+const inactiveGroupBuysOption = { label: "Inactive", value: "Inactive" };
+
+
+const filterOptions = [
+  allGroupBuysOption,
+  activeGroupBuysOption,
+  inactiveGroupBuysOption
+];
+
+// function GroupBuyList(props) {
+//   const groupBuys = props.groupBuys;
+//   const cards = groupBuys.map(groupBuy => 
+    
+//   );
+// }
 
 export class GroupBuyCustomer extends React.Component {
   constructor(props) {
@@ -23,7 +36,7 @@ export class GroupBuyCustomer extends React.Component {
       firebaseUser: null,
       allGroupBuys: [],
       filteredGroupBuys: [],
-      groupBuy: "",
+      filterOption: allGroupBuysOption,
     }
   }
 
@@ -90,12 +103,11 @@ export class GroupBuyCustomer extends React.Component {
       }
     ];
 
-    const allGroupBuys = [allGroupBuysOption];
+    const allGroupBuys = [];
     data.forEach(group => allGroupBuys.push({ label: group.area, value: group.area }));
 
     this.setState({
       allGroupBuys: allGroupBuys,
-      groupBuy: allGroupBuysOption,
       filteredGroupBuys: allGroupBuys
     });
   }
@@ -103,14 +115,14 @@ export class GroupBuyCustomer extends React.Component {
   filterGroupBuy = async(selectedOption) => {
     let filteredGroupBuys = this.state.allGroupBuys;
 
-    if (selectedOption.value !== "All Group Buys") {
+    if (selectedOption.value !== allGroupBuysOption.value) {
       filteredGroupBuys = this.state.allGroupBuys.filter(groupBuy => {
         return groupBuy.area === selectedOption.value;
       });
     }
 
     this.setState({ 
-      groupBuy: selectedOption,
+      filterOption: selectedOption,
       filteredGroupBuys: filteredGroupBuys 
     });
   }
@@ -148,11 +160,11 @@ export class GroupBuyCustomer extends React.Component {
             <Select
                 isDisabled={this.state.allGroupBuys.length === 0}
                 name="groupBuy"
-                options={this.state.allGroupBuys}
-                value={this.state.groupBuy}
+                options={filterOptions}
+                value={this.state.filterOption}
                 onChange={this.filterGroupBuy}
-                placeholder="Filter By Group Name"
             />
+            {/* <GroupBuyList groupbuys={this.state.filteredGroupBuys}/> */}
           </div>
         }
         </div>

--- a/src/Components/GroupBuyCustomer.js
+++ b/src/Components/GroupBuyCustomer.js
@@ -3,9 +3,10 @@ import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
 import { withRouter } from "react-router-dom";
 import Select from "react-select";
 import { db, firebase, uiConfig } from "./Firestore";
-import "../App.css";
-import { Card, CardContent, makeStyles, Table, TableBody, TableCell, 
+import { Badge, Card, CardContent, makeStyles, Table, TableBody, TableCell, 
   TableFooter, TableHead, TablePagination, TableRow } from "@material-ui/core";
+  import { withStyles } from '@material-ui/core/styles';
+import "../App.css";
 
 const analytics = firebase.analytics();
 
@@ -24,10 +25,25 @@ const filterOptions = [
 ];
 
 const useStyles = makeStyles({
+  root: {
+    marginTop: 10
+  },
   paginationcell: {
     borderBottom: "none",
   },
 });
+
+const ActiveBadge = withStyles((theme) => ({
+  badge: {
+    backgroundColor: "lightgreen",
+  },
+}))(Badge);
+
+const InactiveBadge = withStyles((theme) => ({
+  badge: {
+    backgroundColor: "lightgrey",
+  },
+}))(Badge);
 
 function GroupBuyTable(props) {
   const classes = useStyles();
@@ -48,7 +64,7 @@ function GroupBuyTable(props) {
   };
 
   return (
-    <Table size="small" aria-label="a dense table">
+    <Table className={classes.root} size="small" aria-label="a dense table">
       <TableHead>
         <TableRow>
           <TableCell align="center">Item Name</TableCell>
@@ -105,7 +121,24 @@ function CustomerGroupBuyList(props) {
       }}
     >
       <CardContent>
-        <p className="card-title">{ groupBuy.hawker }</p>
+        <div className="col-sm-12">
+          <a 
+            className="card-title"
+            href={"/groupbuy/" + groupBuy.hawker}
+          >
+            { groupBuy.hawker }
+          </a>
+          { groupBuy.active 
+            ? <ActiveBadge 
+                badgeContent="Active" 
+                style={{ float: "right" }}
+              />
+            : <InactiveBadge 
+                badgeContent="Inactive" 
+                style={{ float: "right" }} 
+              />
+          }
+        </div>
         <GroupBuyTable rows={groupBuy.items} />
       </CardContent>
     </Card>
@@ -353,6 +386,10 @@ export class GroupBuyCustomer extends React.Component {
                     options={filterOptions}
                     value={this.state.filterOption}
                     onChange={this.updateFilteredGroupBuys}
+                    styles={{
+                      // fixes the overlapping problem of the component with badge
+                      menu: provided => ({ ...provided, zIndex: 9999 })
+                    }}
                 />
               </div>
             </div>

--- a/src/Components/Groupbuy.js
+++ b/src/Components/Groupbuy.js
@@ -247,6 +247,10 @@ export class Groupbuy extends React.Component {
     });
   };
 
+  handleView = (event) => {
+    this.props.history.push("/groupbuy-customer");
+  }
+
   renderRedirect = () => {
     if (this.state.redirect) {
       // let areaGroupbuys = [];
@@ -360,6 +364,14 @@ export class Groupbuy extends React.Component {
                     {this.state.create ? <>Cancel New Groupbuy</> : <> Create New Groupbuy</>}
 
                   </Button>
+                  <Button
+                    onClick={this.handleView.bind(this)}
+                    style={{
+                      backgroundColor: "#b48300",
+                      borderColor: "#b48300",
+                      margin: "10px"
+                    }}
+                  >View My Groupbuys</Button>
                 </span>
               </div>
               {/* Display create form if user creates new groupbuy */}

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -19,6 +19,7 @@ import Driver from "./Driver";
 import Delivery from "./Delivery";
 import Orders from "./Orders";
 import Groupbuy from "./Groupbuy";
+import GroupBuyCustomer from "./GroupBuyCustomer";
 import GroupbuyList from "./GroupbuyList";
 import Deliveries from "./Deliveries";
 import Search from "./Search";
@@ -51,6 +52,7 @@ export default {
   Delivery,
   Orders,
   Groupbuy,
+  GroupBuyCustomer,
   GroupbuyList,
   Deliveries,
   Search,


### PR DESCRIPTION
This pull request creates a new page `/groupbuy-customer` for customers to view their group buys. The page can be reached directly by the link, or via a button in the `/groupbuy` page:

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/24493463/84777577-54fe2e00-b014-11ea-903a-8acccf0126fd.png">

When a customer first accesses the page, they will have to verify their phone number using Firebase authentication (similar to how it is done in `/orders`):

<img width="584" alt="image" src="https://user-images.githubusercontent.com/24493463/84777652-73fcc000-b014-11ea-91ae-2391de8a95a2.png">

Thereafter, they can see their group buys:

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/24493463/84777714-8a0a8080-b014-11ea-8891-334f69bb39b7.png">

Since I do not have edit access to the Firebase databases, I am currently using dummy data in `getGroupBuyCustomerData`. However, I am envisioning a separate database for the group buy customers with the following format:
```
hawker: String,
active: boolean,
area: String,
items: Array of group buy items with {name, quantity, price}
```

This is to facilitate the data retrieval to populate the page since it is [difficult to search directly from the existing `hawkers` database](https://stackoverflow.com/questions/54081799/firestore-to-query-by-an-arrays-field-value). 